### PR TITLE
Update bounds

### DIFF
--- a/servant-event-stream.cabal
+++ b/servant-event-stream.cabal
@@ -34,16 +34,16 @@ library
     OverloadedStrings
 
   build-depends:
-      base                  >= 4.10 && < 4.15
+      base                  >= 4.10 && < 5
     , binary                >= 0.7 && < 0.11
     , http-media            >= 0.7.1.3 && < 0.9
-    , lens                  >= 4.17 && < 4.20
+    , lens                  >= 4.17 && < 5.3
     , pipes                 >= 4.3.9 && < 4.4
     , servant-foreign       >= 0.15 && < 0.16
     , servant-js            >= 0.9.4 && < 0.10
     , servant-pipes         >= 0.15 && < 0.16
-    , servant-server        >= 0.15 && < 0.19
-    , text                  >= 1.2.3 && < 1.3
+    , servant-server        >= 0.15 && < 0.21
+    , text                  >= 1.2.3 && < 2.1
     , wai-extra             >= 3.0 && < 3.2
 
   hs-source-dirs:      src


### PR DESCRIPTION
I took bounds from https://github.com/bflyblue/servant-event-stream/pull/5 and tested that library compiles with GHC 9.4.5