### PR TITLE
Support parsing of SSE events

### DIFF
--- a/servant-event-stream.cabal
+++ b/servant-event-stream.cabal
@@ -1,6 +1,6 @@
 cabal-version: >=1.10
 name: servant-event-stream
-version: 0.3.0.1
+version: 0.4.0.0
 stability: alpha
 synopsis: Servant support for Server-Sent events
 category: Servant, Web

--- a/servant-event-stream.cabal
+++ b/servant-event-stream.cabal
@@ -31,10 +31,12 @@ library
     OverloadedStrings
 
   build-depends:
+    attoparsec >=0.13.2.2 && <0.15,
     base >=4.10 && <4.20,
     bytestring >=0.11.1.0 && <0.13,
     http-media >=0.7.1.3 && <0.9,
     lens >=4.17 && <5.4,
+    servant >=0.15 && <0.21,
     servant-foreign >=0.15 && <0.17,
     servant-server >=0.15 && <0.21,
     text >=1.2.3 && <2.2


### PR DESCRIPTION
Hey @bflyblue! 

Much like the author of #4 I found myself wanting to use this library to _parse_ SSE for communicating with an LLM API. 

The work to do so was not so bad - I didn't realize that #5 existed though until after it was done.  Perhaps for the better since I didn't have knowledge of the pre-Servant.API.Stream API. 

Some notes:
- Adding a `FromServerEvent` class fit well parity wise with `ToServerEvent`
- I made the (probably breaking) change of converting `ToServerEvent` to `Text`.  This matches [the specs](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) better which explicitly specify that streams *must* be UTF-8.  
- The spec says that newlines in the form of \r\n, \r, and \n should all be supported when interpreting a stream, so I've done that. 
- I needed to expose `ServerEventFraming` for my use case because I'm trying to make a streaming POST request.  My endpoint looks like `StreamPost ServerEventFraming EventStream (SourceIO x)`
- I went for the lightest touch possible changing this file, the tests from #5 are probably salvageable.  We could also add roundtrip-tests around `FramingRender` <-> `FramingUnrender` and `ToServerEvent` <-> `FromServerEvent` 


