### PR TITLE
Support GHC 9.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755704039,
-        "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
+        "lastModified": 1771574726,
+        "narHash": "sha256-D1PA3xQv/s4W3lnR9yJFSld8UOLr0a/cBWMQMXS+1Qg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9cb344e96d5b6918e94e1bca2d9f3ea1e9615545",
+        "rev": "c217913993d6c6f6805c3b1a3bda5e639adfde6d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "servant-event-stream";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
   };
 
   outputs =
@@ -23,7 +23,7 @@
       hpkgsFor =
         system: pkgs:
         with pkgs.haskell.lib;
-        pkgs.haskell.packages.ghc98.override { overrides = self: super: { }; };
+        pkgs.haskell.packages.ghc912.override { overrides = self: super: { }; };
     in
     {
       packages = forallSystems (

--- a/src/Servant/API/EventStream.hs
+++ b/src/Servant/API/EventStream.hs
@@ -65,7 +65,6 @@ import Data.Kind (Type)
 import Data.Semigroup
 #endif
 import Data.Text (Text)
-import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Network.HTTP.Media ((//), (/:))
 import qualified Servant as S
@@ -76,7 +75,7 @@ import qualified Servant.Foreign.Internal as SFI
   <https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format>
 -}
 data ServerSentEvents (a :: Type)
-  deriving (Typeable, Generic)
+  deriving (Generic)
 
 instance S.HasLink (ServerSentEvents a) where
   type MkLink (ServerSentEvents a) r = r


### PR DESCRIPTION
## Summary
- Update Nix flake to nixos-25.11 with GHC 9.12
- Remove redundant `Typeable` deriving to fix `-Wderiving-typeable` warning new in GHC 9.12

## Test plan
- [x] `cabal build` succeeds with no warnings on GHC 9.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)