### PR TITLE
Support GHC 8.6 through 9.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,25 @@ on:
   pull_request:
   push:
 jobs:
-  tests:
+  nix:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
     - run: nix build
     - run: nix flake check
+
+  cabal:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: ['8.0', '8.10', '9.2', '9.8', '9.12', '9.14']
+    name: GHC ${{ matrix.ghc }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: haskell-actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+    - run: cabal update
+    - run: cabal build
+    - run: cabal test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['8.0', '8.10', '9.2', '9.8', '9.12', '9.14']
+        ghc: ['8.0', '8.10', '9.2', '9.8', '9.12']
     name: GHC ${{ matrix.ghc }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['8.0', '8.10', '9.2', '9.8', '9.12']
+        ghc: ['8.6', '8.10', '9.2', '9.8', '9.12']
     name: GHC ${{ matrix.ghc }}
     steps:
     - uses: actions/checkout@v4
     - uses: haskell-actions/setup@v2
+      id: setup
       with:
         ghc-version: ${{ matrix.ghc }}
     - run: cabal update
+    - run: cabal freeze
+    - uses: actions/cache@v4
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
     - run: cabal build
     - run: cabal test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 0.3.2.0 -- 2026-02-23
 
-* Support GHC 8.0 through 9.14 (base 4.9 to 4.22).
+* Support GHC 8.0 through 9.12 (base 4.9 to 4.21).
 * Remove redundant `Typeable` deriving to fix `-Wderiving-typeable` warning on GHC 9.12+.
-* Add CI test matrix for GHC 8.0, 8.10, 9.2, 9.8, 9.12, 9.14.
+* Add CI test matrix for GHC 8.0, 8.10, 9.2, 9.8, 9.12.
 
 ## 0.3.1.1 -- 2026-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for servant-event-stream
 
+## 0.3.2.0 -- 2026-02-23
+
+* Support GHC 8.0 through 9.14 (base 4.9 to 4.22).
+* Remove redundant `Typeable` deriving to fix `-Wderiving-typeable` warning on GHC 9.12+.
+* Add CI test matrix for GHC 8.0, 8.10, 9.2, 9.8, 9.12, 9.14.
+
 ## 0.3.1.1 -- 2026-02-23
 
 * Constrain base bounds in test suite to match library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 0.3.2.0 -- 2026-02-23
 
-* Support GHC 8.0 through 9.12 (base 4.9 to 4.21).
+* Support GHC 8.6 through 9.12 (base 4.12 to 4.21).
 * Remove redundant `Typeable` deriving to fix `-Wderiving-typeable` warning on GHC 9.12+.
-* Add CI test matrix for GHC 8.0, 8.10, 9.2, 9.8, 9.12.
+* Add CI test matrix for GHC 8.6, 8.10, 9.2, 9.8, 9.12.
 
 ## 0.3.1.1 -- 2026-02-23
 

--- a/servant-event-stream.cabal
+++ b/servant-event-stream.cabal
@@ -31,7 +31,7 @@ library
     OverloadedStrings
 
   build-depends:
-    base >=4.9 && <4.23,
+    base >=4.9 && <4.22,
     bytestring >=0.11.1.0 && <0.13,
     http-media >=0.7.1.3 && <0.9,
     lens >=4.17 && <5.4,
@@ -48,4 +48,4 @@ test-suite tests-default
   main-is: Spec.hs
   hs-source-dirs: tests
   default-language: Haskell2010
-  build-depends: base >=4.9 && <4.23
+  build-depends: base >=4.9 && <4.22

--- a/servant-event-stream.cabal
+++ b/servant-event-stream.cabal
@@ -31,7 +31,7 @@ library
     OverloadedStrings
 
   build-depends:
-    base >=4.9 && <4.22,
+    base >=4.12 && <4.22,
     bytestring >=0.11.1.0 && <0.13,
     http-media >=0.7.1.3 && <0.9,
     lens >=4.17 && <5.4,
@@ -48,4 +48,4 @@ test-suite tests-default
   main-is: Spec.hs
   hs-source-dirs: tests
   default-language: Haskell2010
-  build-depends: base >=4.9 && <4.22
+  build-depends: base >=4.12 && <4.22

--- a/servant-event-stream.cabal
+++ b/servant-event-stream.cabal
@@ -1,6 +1,6 @@
 cabal-version: >=1.10
 name: servant-event-stream
-version: 0.3.1.1
+version: 0.3.2.0
 stability: alpha
 synopsis: Servant support for Server-Sent events
 category: Servant, Web
@@ -14,7 +14,7 @@ license: BSD3
 license-file: LICENSE
 author: Shaun Sharples
 maintainer: shaun.sharples@gmail.com
-copyright: (c) 2025 Shaun Sharples
+copyright: (c) 2026 Shaun Sharples
 build-type: Simple
 extra-source-files:
   CHANGELOG.md
@@ -31,7 +31,7 @@ library
     OverloadedStrings
 
   build-depends:
-    base >=4.10 && <4.22,
+    base >=4.9 && <4.23,
     bytestring >=0.11.1.0 && <0.13,
     http-media >=0.7.1.3 && <0.9,
     lens >=4.17 && <5.4,
@@ -48,4 +48,4 @@ test-suite tests-default
   main-is: Spec.hs
   hs-source-dirs: tests
   default-language: Haskell2010
-  build-depends: base >=4.10 && <4.22
+  build-depends: base >=4.9 && <4.23

--- a/servant-event-stream.cabal
+++ b/servant-event-stream.cabal
@@ -42,6 +42,8 @@ library
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall
+  if impl(ghc < 9.4)
+    ghc-options: -Wno-unticked-promoted-constructors
 
 test-suite tests-default
   type: exitcode-stdio-1.0

--- a/src/Servant/API/EventStream.hs
+++ b/src/Servant/API/EventStream.hs
@@ -12,7 +12,7 @@
 {- |
 Module: Servant.API.EventStream
 Description: Server Sent Events for Servant Streams
-Copyright: (c) 2024 Shaun Sharples
+Copyright: (c) 2026 Shaun Sharples
 License: BSD3
 Stability: alpha
 -}


### PR DESCRIPTION
## Summary
- Set base bounds to `>=4.12 && <4.22` (GHC 8.6 through 9.12)
- Remove redundant `Typeable` deriving to fix `-Wderiving-typeable` warning on GHC 9.12+
- Add CI test matrix for GHC 8.6, 8.10, 9.2, 9.8, 9.12 with cabal store caching
- Update copyright year to 2026
- Bump version to 0.3.2.0

## Test plan
- [ ] CI matrix passes for all 5 GHC versions
- [ ] Nix build still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)